### PR TITLE
[iOS]Add support for Cordova 4.x.

### DIFF
--- a/src/ios/Flashlight.m
+++ b/src/ios/Flashlight.m
@@ -6,38 +6,44 @@
 
 - (void)available:(CDVInvokedUrlCommand*)command {
     CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:[self deviceHasFlashlight]];
-    NSString *callbackId = command.callbackId;
-    [self writeJavascript:[pluginResult toSuccessCallbackString:callbackId]];
+
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
 - (void)switchOn:(CDVInvokedUrlCommand*)command {
+    CDVPluginResult* pluginResult;
+
     if ([self deviceHasFlashlight]) {
         AVCaptureDevice *device = [AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeVideo];
         [device lockForConfiguration:nil];
         [device setTorchMode:AVCaptureTorchModeOn];
         [device setFlashMode:AVCaptureFlashModeOn];
         [device unlockForConfiguration];
-        CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
-        [self writeJavascript:[pluginResult toSuccessCallbackString:command.callbackId]];
+        
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
     } else {
-        CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Device is not capable of using the flashlight. Please test with flashlight.available()"];
-        [self writeJavascript:[pluginResult toErrorCallbackString:command.callbackId]];
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR
+                                         messageAsString:@"Device is not capable of using the flashlight. Please test with flashlight.available()"];
     }
+
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
 - (void)switchOff:(CDVInvokedUrlCommand*)command {
+    CDVPluginResult* pluginResult;
     if ([self deviceHasFlashlight]) {
         AVCaptureDevice *device = [AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeVideo];
         [device lockForConfiguration:nil];
         [device setTorchMode:AVCaptureTorchModeOff];
         [device setFlashMode:AVCaptureFlashModeOff];
         [device unlockForConfiguration];
-        CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
-        [self writeJavascript:[pluginResult toSuccessCallbackString:command.callbackId]];
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
     } else {
-        CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Device is not capable of using the flashlight. Please test with flashlight.available()"];
-        [self writeJavascript:[pluginResult toErrorCallbackString:command.callbackId]];
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR
+                                         messageAsString:@"Device is not capable of using the flashlight. Please test with flashlight.available()"];
     }
+
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
 -(BOOL)deviceHasFlashlight {
@@ -45,6 +51,7 @@
         AVCaptureDevice *device = [AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeVideo];
         return [device hasTorch] && [device hasFlash];
     }
+
     return false;
 }
 


### PR DESCRIPTION
**Description:**
Fix compiler error when building AB project (using Cordova v4.x or later) with latest plugin (v2.0.3).

> Replace depricated method `writeJavascript:` with `commandDelegate`'s `sendPluginResult:callbackId:` method.
> See [API Changes in cordova-ios-4.0](https://github.com/apache/cordova-ios/blob/master/guides/API%20changes%20in%204.0.md) for more details regarding API changes.

**TeamPulse:** [[Plugins][iOS] iOS Build for Cordova 5.0 fails with Telerik Analytics plugin](http://teampulse.telerik.com/view#item/315412)
**Tests Report:** [MarketPluginTests Report](http://ice-qajenkins:8080/view/Samples+Plugins/job/CLI_Build_Marketplace_Combo_Plugins_LIN/138/HTML_Report_and_Logs/)
