### PR TITLE
Fix incompatibility for devices where we can not turn off the disable…

### DIFF
--- a/src/android/nl/xservices/plugins/Flashlight.java
+++ b/src/android/nl/xservices/plugins/Flashlight.java
@@ -31,6 +31,7 @@ public class Flashlight extends CordovaPlugin {
 
   private static Boolean capable;
   private boolean releasing;
+  private boolean mFixFlashLight = false;
 
   @SuppressWarnings("deprecation")
   private Camera mCamera;
@@ -152,15 +153,14 @@ public class Flashlight extends CordovaPlugin {
   @TargetApi(23)
   private void setTorchMode(CameraManager cameraManager, String id, boolean switchOn) throws CameraAccessException {
     // since folks may not use SDK 23 to compile we'll use reflection as a temporary solution
-    try {
-      final Method setTorchMode = cameraManager.getClass().getMethod("setTorchMode", String.class, boolean.class);
-      setTorchMode.invoke(cameraManager, id, switchOn);
-      callbackContext.success();
-    } catch (ReflectiveOperationException e) {
-      callbackContext.error(e.getMessage());
-    } catch (Throwable t) {
-      callbackContext.error(t.getMessage());
-    }
+    if (mFixFlashLight) {
+            cameraManager.setTorchMode(id, switchOn);
+        } else {
+            if (switchOn) {
+                cameraManager.setTorchMode(id, switchOn);
+            }
+        }
+        mFixFlashLight = switchOn;
   }
 
   public boolean hasPermisssion() {


### PR DESCRIPTION
When i using this plug in on the device Sony e5633, Android 6.0. I'm facing with problem when at the start application, application have a error
`FATAL EXCEPTION: main
Process: uk.co.sparkenergy.androidapp2, PID: 31200    java.lang.IllegalArgumentException: Receiver not registered: android.hardware.camera2.CameraManager$1@6e1ab65
                                                                               at android.app.LoadedApk.forgetReceiverDispatcher(LoadedApk.java:793)
                                                                               at android.app.ContextImpl.unregisterReceiver(ContextImpl.java:1200)
                                                                               at android.hardware.camera2.CameraManager$3.run(CameraManager.java:1266)
                                                                               at android.os.Handler.handleCallback(Handler.java:815)
                                                                               at android.os.Handler.dispatchMessage(Handler.java:104)
                                                                               at android.os.Looper.loop(Looper.java:207)
                                                                               at android.app.ActivityThread.main(ActivityThread.java:5763)
                                                                               at java.lang.reflect.Method.invoke(Native Method)
                                                                               at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:789)
                                                                               at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:679)`
This problem cause, when we start application, in CameraManager.setTorch set the false paramater, but flashlight already turn off. So i offer my decision in example of my code.
